### PR TITLE
Add module grafana

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The support collector allows our customers to collect relevant information from 
 A resulting ZIP file can then be provided to our support team for further inspection.
 
 If you are a customer, you can contact us at [support@netways.de](mailto:support@netways.de) or
-[netways.de/contact](https://www.netways.de/contact).
+[netways.de/en/contact/](https://www.netways.de/en/contact/).
 
 > **WARNING:** DO NOT transfer the generated file over insecure connections or by
 email, it contains potential sensitive information!
@@ -116,6 +116,18 @@ Module `puppet`
 * Puppet module list
 
 See [modules/puppet/collector.go](modules/puppet/collector.go) for details.
+
+### Grafana
+
+Module `grafana`
+
+* Configuration files from`/etc/grafana` and `/usr/share/grafana`
+* Package Versions
+* Service status
+* grafana-cli version
+* grafana-cli plugins list
+
+See [modules/grafana/collector.go](modules/grafana/collector.go) for details.
 
 ## Supported systems
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/NETWAYS/support-collector/modules/ansible"
 	"github.com/NETWAYS/support-collector/modules/base"
+	"github.com/NETWAYS/support-collector/modules/grafana"
 	"github.com/NETWAYS/support-collector/modules/icinga2"
 	"github.com/NETWAYS/support-collector/modules/icingadirector"
 	"github.com/NETWAYS/support-collector/modules/icingaweb2"
@@ -48,6 +49,7 @@ var modules = map[string]func(*collection.Collection){
 	"mysql":           mysql.Collect,
 	"ansible":         ansible.Collect,
 	"puppet":          puppet.Collect,
+	"grafana":         grafana.Collect,
 }
 
 var moduleOrder = []string{
@@ -58,6 +60,7 @@ var moduleOrder = []string{
 	"mysql",
 	"ansible",
 	"puppet",
+	"grafana",
 }
 
 var (

--- a/modules/grafana/collector.go
+++ b/modules/grafana/collector.go
@@ -1,0 +1,60 @@
+package grafana
+
+import (
+	"github.com/NETWAYS/support-collector/pkg/collection"
+	"github.com/NETWAYS/support-collector/pkg/obfuscate"
+	"os"
+)
+
+const ModuleName = "grafana"
+
+var relevantPaths = []string{
+	"/etc/grafana",
+	"/usr/share/grafana",
+}
+
+var files = []string{
+	"/etc/grafana",
+}
+
+var commands = map[string][]string{
+	"grafana-cli-version.txt":      {"grafana-cli", "-v"},
+	"grafana-cli-plugins-list.txt": {"grafana-cli", "plugins", "ls"},
+}
+
+var obfuscators = []*obfuscate.Obfuscator{
+	obfuscate.NewFile(`(?i)(?:password|token)\s*=\s*(.*)`, `ini`),
+}
+
+func Detect() bool {
+	for _, path := range relevantPaths {
+		_, err := os.Stat(path)
+		if err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func Collect(c *collection.Collection) {
+	if !Detect() {
+		c.Log.Info("Could not find grafana")
+		return
+	}
+
+	c.Log.Info("Collecting grafana information")
+
+	c.RegisterObfuscators(obfuscators...)
+
+	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*grafana*", "*chrome*", "*chromium*")
+	c.AddServiceStatusRaw(ModuleName+"/service.txt", "grafana-server")
+
+	for _, file := range files {
+		c.AddFiles(ModuleName, file)
+	}
+
+	for name, cmd := range commands {
+		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+	}
+}

--- a/modules/grafana/collector.go
+++ b/modules/grafana/collector.go
@@ -23,7 +23,10 @@ var commands = map[string][]string{
 }
 
 var obfuscators = []*obfuscate.Obfuscator{
-	obfuscate.NewFile(`(?i)(?:password|token)\s*=\s*(.*)`, `ini`),
+	// grafana.ini
+	obfuscate.NewFile(`(?i)(?:password|token|key|secret).*\s*=\s*(.*)`, `ini`),
+	// e.g. ldap.toml
+	obfuscate.NewFile(`(?i)(?:password|token|key|secret).*\s*=\s*(.*)`, `toml`),
 }
 
 func Detect() bool {

--- a/modules/grafana/collector_test.go
+++ b/modules/grafana/collector_test.go
@@ -1,0 +1,14 @@
+package grafana
+
+import (
+	"bytes"
+	"github.com/NETWAYS/support-collector/pkg/collection"
+	"testing"
+)
+
+func TestCollect(t *testing.T) {
+	c := collection.New(&bytes.Buffer{})
+	// c.Log = logrus.StandardLogger()
+
+	Collect(c)
+}


### PR DESCRIPTION
Extension by the module-grafana.

The following data is collected:
 * Configuration from /etc/grafana & /usr/share/grafana
 * Package versions 
 * Service status
 * grafana-cli version
 * grafana-cli plugins list

See [modules/grafana/collector.go](modules/grafana/collector.go) for details.