### PR TITLE
Icinga2: Add PluginDir in files and plugins in packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ See [modules/base/collector.go](modules/base/collector.go) for details.
 Module: `icinga2`
 
 * Configuration from `/etc/icinga2`
-* Files in `/usr/lib64/nagios/plugins`
+* Files in PluginDir
 * Package information
 * Service status
 * Config check result

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ See [modules/base/collector.go](modules/base/collector.go) for details.
 Module: `icinga2`
 
 * Configuration from `/etc/icinga2`
+* Files in `/usr/lib64/nagios/plugins`
 * Package information
 * Service status
 * Config check result

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -12,6 +12,7 @@ const ModuleName = "icinga2"
 var files = []string{
 	"/etc/icinga2",
 	"/var/log/icinga2/icinga2.log",
+	"/usr/lib64/nagios/plugins",
 }
 
 var optionalFiles = []string{
@@ -49,7 +50,12 @@ func Collect(c *collection.Collection) {
 
 	c.RegisterObfuscators(obfuscators...)
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*icinga2*")
+	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt",
+		"*icinga2*",
+		"netways-plugin*",
+		"monitoring-plugin*",
+		"nagios-plugin*")
+
 	c.AddServiceStatusRaw(ModuleName+"/service.txt", "icinga2")
 
 	if collection.DetectServiceManager() == "systemd" {

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -12,7 +12,11 @@ const ModuleName = "icinga2"
 var files = []string{
 	"/etc/icinga2",
 	"/var/log/icinga2/icinga2.log",
+}
+
+var pluginFiles = []string{
 	"/usr/lib64/nagios/plugins",
+	"/usr/lib/nagios/plugins",
 }
 
 var optionalFiles = []string{
@@ -65,6 +69,8 @@ func Collect(c *collection.Collection) {
 	for _, file := range files {
 		c.AddFiles(ModuleName, file)
 	}
+
+	c.AddFilesAtLeastOne(ModuleName, pluginFiles...)
 
 	for _, file := range optionalFiles {
 		if _, err := os.Stat(file); err != nil {


### PR DESCRIPTION
Extension of the Icinga 2 module with check plugins.

Files:
* `/usr/lib64/nagios/plugins`

Packages:
* `netways-plugin*`
* `monitoring-plugin*`
* `nagios-plugin*`