### PR TITLE
append hostname to filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -183,7 +183,19 @@ func handleArguments() {
 
 // buildFileName returns a filename to store the output of support collector.
 func buildFileName() string {
-	return FilePrefix + "-" + time.Now().Format("20060102-1504") + ".zip"
+	return GetHostnameWithoutDomain() + "-" + FilePrefix + "-" + time.Now().Format("20060102-1504") + ".zip"
+}
+
+func GetHostnameWithoutDomain() string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		logrus.Error(err)
+	}
+	result, _, found := strings.Cut(hostname, ".")
+	if found != true {
+		return hostname
+	}
+	return result
 }
 
 func NewCollection(outputFile string) (*collection.Collection, func()) {

--- a/main.go
+++ b/main.go
@@ -191,10 +191,12 @@ func GetHostnameWithoutDomain() string {
 	if err != nil {
 		logrus.Error(err)
 	}
+
 	result, _, found := strings.Cut(hostname, ".")
 	if found != true {
 		return hostname
 	}
+
 	return result
 }
 

--- a/main.go
+++ b/main.go
@@ -193,7 +193,7 @@ func GetHostnameWithoutDomain() string {
 	}
 
 	result, _, found := strings.Cut(hostname, ".")
-	if found != true {
+	if !found {
 		return hostname
 	}
 


### PR DESCRIPTION
Append hostname to filename to better identify files.

Example:
psupport-ic01-netways-support-20220523-0632.zip

Review needed.