### PR TITLE
add module icingadb

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If you want to see what is collected, add `--verbose`.
 ```
 Usage of support-collector:
   -o, --output string              Output file for the ZIP content (default "netways-support-20220523-0929.zip")
-      --enable strings             List of enabled module (default [base,icinga2,icingaweb2,icinga-director,mysql,influxdb,postgresql,ansible,puppet,grafana,graphite])
+      --enable strings             List of enabled module (default [base,icinga2,icingaweb2,icinga-director,icingadb,mysql,influxdb,postgresql,ansible,puppet,grafana,graphite])
       --disable strings            List of disabled module
       --command-timeout duration   Timeout for command execution in modules (default 1m0s)
   -v, --verbose                    Enable verbose logging

--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ Module: `icingaweb2`
 
 See [modules/icingaweb2/collector.go](modules/icingaweb2/collector.go) for details.
 
+### IcingaDB
+
+Module: `icingadb`
+
+* Configuration from `/etc/icingadb`, `/etc/icingadb-redis` and `/etc/icinga2/features-enabled/icingadb.conf`
+* Service status from `icingadb`, `icingadb-redis` and `icingadb-redis-server`
+* Package information
+* Journal logs from `icingadb`, `icingadb-redis` and `icingadb-redis-server`
+
 ### Icinga Director
 
 Module: `icinga-director`

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/NETWAYS/support-collector/modules/grafana"
 	"github.com/NETWAYS/support-collector/modules/graphite"
 	"github.com/NETWAYS/support-collector/modules/icinga2"
+	"github.com/NETWAYS/support-collector/modules/icingadb"
 	"github.com/NETWAYS/support-collector/modules/icingadirector"
 	"github.com/NETWAYS/support-collector/modules/icingaweb2"
 	"github.com/NETWAYS/support-collector/modules/influxdb"
@@ -56,21 +57,25 @@ var modules = map[string]func(*collection.Collection){
 	"puppet":          puppet.Collect,
 	"grafana":         grafana.Collect,
 	"graphite":        graphite.Collect,
+	"icingadb":        icingadb.Collect,
 }
 
-var moduleOrder = []string{
-	"base",
-	"icinga2",
-	"icingaweb2",
-	"icinga-director",
-	"mysql",
-	"influxdb",
-	"postgresql",
-	"ansible",
-	"puppet",
-	"grafana",
-	"graphite",
-}
+var (
+	moduleOrder = []string{
+		"base",
+		"icinga2",
+		"icingaweb2",
+		"icinga-director",
+		"icingadb",
+		"mysql",
+		"influxdb",
+		"postgresql",
+		"ansible",
+		"puppet",
+		"grafana",
+		"graphite",
+	}
+)
 
 var (
 	commandTimeout                  = 60 * time.Second

--- a/modules/icingadb/collector.go
+++ b/modules/icingadb/collector.go
@@ -1,0 +1,78 @@
+package icingadb
+
+import (
+	"github.com/NETWAYS/support-collector/pkg/collection"
+	"github.com/NETWAYS/support-collector/pkg/obfuscate"
+	"os"
+)
+
+const (
+	ModuleName = "icingadb"
+)
+
+var relevantPaths = []string{
+	"/etc/icingadb",
+}
+
+var files = []string{
+	"/etc/icingadb",
+	"/etc/icingadb-redis",
+	"/etc/icinga2/features-enabled/icingadb.conf",
+}
+
+var services = []string{
+	"icingadb",
+	"icingadb-redis",
+	"icingadb-redis-server",
+}
+
+var journalctlLogs = map[string]collection.JournalElement{
+	"journalctl-icingadb.txt":              {Service: "icingadb.service"},
+	"journalctl-icingadb-redis.txt":        {Service: "icingadb-redis.service"},
+	"journalctl-icingadb-redis-server.txt": {Service: "icingadb-redis-server.service"},
+}
+
+var obfuscators = []*obfuscate.Obfuscator{
+	obfuscate.NewFile(`(?i)(?:password)\s*=\s*(.*)`, `conf`),
+}
+
+func Detect() bool {
+	for _, path := range relevantPaths {
+		_, err := os.Stat(path)
+		if err == nil {
+			return true
+		}
+	}
+
+	return false
+}
+
+func Collect(c *collection.Collection) {
+	if !Detect() {
+		c.Log.Info("Could not find IcingaDB")
+		return
+	}
+
+	c.Log.Info("Collecting IcingaDB information")
+
+	c.RegisterObfuscators(obfuscators...)
+
+	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt",
+		"*icingadb*",
+		"icingadb-redis",
+	)
+
+	for _, file := range files {
+		c.AddFiles(ModuleName, file)
+	}
+
+	for _, service := range services {
+		c.AddServiceStatusRaw(ModuleName+"/service-"+service+".txt", service)
+	}
+
+	for name, element := range journalctlLogs {
+		if service, err := collection.FindServices(element.Service); err == nil && len(service) > 0 {
+			c.AddCommandOutput(ModuleName+"/"+name, "journalctl", "-u", element.Service, "--since", "7 days ago")
+		}
+	}
+}

--- a/modules/icingadb/collector_test.go
+++ b/modules/icingadb/collector_test.go
@@ -1,0 +1,14 @@
+package icingadb
+
+import (
+	"bytes"
+	"github.com/NETWAYS/support-collector/pkg/collection"
+	"testing"
+)
+
+func TestCollect(t *testing.T) {
+	c := collection.New(&bytes.Buffer{})
+	// c.Log = logrus.StandardLogger()
+
+	Collect(c)
+}


### PR DESCRIPTION
Add module for IcingaDB

Following data is collected:
* Configuration from `/etc/icingadb`, `/etc/icingadb-redis` and `/etc/icinga2/features-enabled/icingadb.conf`
* Service status from `icingadb`, `icingadb-redis` and `icingadb-redis-server`
* Package information
* Journal logs from `icingadb`, `icingadb-redis` and `icingadb-redis-server`

Thoughts? @pdorschner 