### PR TITLE
puppet: change version source to facter

### DIFF
--- a/modules/puppet/collector.go
+++ b/modules/puppet/collector.go
@@ -23,9 +23,8 @@ var files = []string{
 }
 
 var commands = map[string][]string{
-	"version-puppet.txt":       {"puppet", "--version"},
-	"version-puppetserver.txt": {"puppetserver", "--version"},
-	"puppet-module-list.txt":   {"puppet", "module", "list"},
+	"facter.txt":             {"facter"},
+	"puppet-module-list.txt": {"puppet", "module", "list"},
 }
 
 func Detect() bool {


### PR DESCRIPTION
Replace version source to facter.

facter is installed by default with every puppet installation. This allows a deeper insight into the puppet information.