### PR TITLE
replace ioutil with os

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,11 +8,17 @@ linters:
     - testpackage  # not needed
     - wrapcheck  # not needed
     - godox  # we still have a lot of TODOs left
-    - revive  # doc is still pending
     - funlen # strange counting for main()
     - varnamelen # we use these here
     - nonamedreturns
     - exhaustruct
+    - scopelint
+    - golint
+    - interfacer # deprecated since v1.38.0
+    - ifshort # v1.48.0
+  enable:
+    - exportloopref
+    - revive
   presets:
     - bugs
     - unused

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func handleArguments() {
 	flag.Parse()
 
 	if printVersion {
-		fmt.Println(Product, "version", buildVersion()) // nolint:forbidigo
+		fmt.Println(Product, "version", buildVersion()) //nolint:forbidigo
 		os.Exit(0)
 	}
 

--- a/modules/icingaweb2/collector.go
+++ b/modules/icingaweb2/collector.go
@@ -3,7 +3,6 @@ package icingaweb2
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -131,7 +130,7 @@ func CollectModuleInfo(c *collection.Collection) {
 		c.Log.Warnf("we need git to inspect modules closer")
 	}
 
-	modulesFiles, err := ioutil.ReadDir(ModulesPath)
+	modulesFiles, err := os.ReadDir(ModulesPath)
 	if err != nil {
 		c.Log.Warnf("Could not list modules in %s - %s", ModulesPath, err)
 		return

--- a/pkg/collection/file.go
+++ b/pkg/collection/file.go
@@ -85,7 +85,7 @@ func LoadFilesFromGlob(prefix, source string) (files []*File, err error) {
 		err = fmt.Errorf("could not glob '%s': %w", source, err)
 		return
 	} else if len(matches) == 0 {
-		err = fmt.Errorf("no files found for glob: '%s'", source) // nolint:goerr113
+		err = fmt.Errorf("no files found for glob: '%s'", source) //nolint:goerr113
 		return
 	}
 
@@ -103,7 +103,7 @@ func LoadFilesFromGlob(prefix, source string) (files []*File, err error) {
 	return
 }
 
-// nolint:nakedret
+//nolint:nakedret
 func LoadFilesFromDirectory(prefix, source string) (files []*File, err error) {
 	err = filepath.Walk(source, func(path string, info os.FileInfo, err error) error {
 		if err != nil {

--- a/pkg/collection/file.go
+++ b/pkg/collection/file.go
@@ -3,7 +3,6 @@ package collection
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -69,7 +68,7 @@ func loadFile(prefix, source string, stat os.FileInfo) (file *File, err error) {
 		Source:   source,
 	}
 
-	file.Data, err = ioutil.ReadFile(source)
+	file.Data, err = os.ReadFile(source)
 	if err != nil {
 		err = fmt.Errorf("could not read file '%s': %w", source, err)
 		return

--- a/pkg/util/testing.go
+++ b/pkg/util/testing.go
@@ -3,7 +3,7 @@ package util
 import (
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
 	"github.com/stretchr/testify/assert"
-	"io/ioutil"
+	"os"
 	"strings"
 	"testing"
 )
@@ -82,7 +82,7 @@ func AssertAllObfuscatorsTested(t *testing.T, obfuscators []*obfuscate.Obfuscato
 func LoadTestdata(t *testing.T, name string) string {
 	t.Helper()
 
-	content, err := ioutil.ReadFile("testdata/" + name)
+	content, err := os.ReadFile("testdata/" + name)
 	if err != nil {
 		t.Errorf("could not load testdata file: %s - %s", name, err)
 		return ""

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-// nolint: gochecknoglobals
+//nolint:gochecknoglobals
 var (
 	version = "0.6.1"
 	commit  = ""


### PR DESCRIPTION
Replace io/ioutil with os, because io/ioutil is deprecated since go 1.16