### PR TITLE
corosync: adjust relevant path

### DIFF
--- a/modules/corosync/collector.go
+++ b/modules/corosync/collector.go
@@ -8,7 +8,7 @@ import (
 const ModuleName = "corosync"
 
 var relevantPaths = []string{
-	"/etc/corosync/service.d",
+	"/etc/corosync",
 }
 
 var possibleDaemons = []string{


### PR DESCRIPTION
The current '/etc/corosync/service.d' path is not mandatory. Better use '/etc/corosync' instead