### PR TITLE
adjust file paths

### DIFF
--- a/modules/ansible/collector.go
+++ b/modules/ansible/collector.go
@@ -3,6 +3,7 @@ package ansible
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "ansible"
@@ -44,10 +45,10 @@ func Collect(c *collection.Collection) {
 	}
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*ansible*")
-	c.AddInstalledPackagesRaw(ModuleName+"/packages-python.txt", "*python*")
-	c.AddInstalledPackagesRaw(ModuleName+"/packages-pip.txt", "*pip*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*ansible*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages-python.txt"), "*python*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages-pip.txt"), "*pip*")
 }

--- a/modules/base/collector.go
+++ b/modules/base/collector.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"gopkg.in/yaml.v3"
 	"os/exec"
+	"path/filepath"
 )
 
 const ModuleName = "base"
@@ -41,13 +42,13 @@ func Collect(c *collection.Collection) {
 
 	// Check if apparmor is installed and get status
 	if _, err := exec.LookPath("apparmor_status"); err == nil {
-		c.AddCommandOutput(ModuleName+"/apparmor-status.txt", "apparmor_status")
+		c.AddCommandOutput(filepath.Join(ModuleName, "apparmor-status.txt"), "apparmor_status")
 	}
 
 	// Check if we can detect SELinux enforcing
 	for _, cmd := range []string{"sestatus", "getenforce"} {
 		if _, err := exec.LookPath(cmd); err == nil {
-			c.AddCommandOutput(ModuleName+"/selinux-status.txt", cmd)
+			c.AddCommandOutput(filepath.Join(ModuleName, "selinux-status.txt"), cmd)
 			break
 		}
 	}
@@ -60,8 +61,7 @@ func Collect(c *collection.Collection) {
 	c.AddFilesIfFound(ModuleName, repositoryFiles...)
 
 	for _, cmd := range commands {
-		name := ModuleName + "/" + cmd[0] + ".txt"
-		c.AddCommandOutput(name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, cmd[0]+".txt"), cmd[0], cmd[1:]...)
 	}
 }
 
@@ -81,7 +81,7 @@ func CollectKernelInfo(c *collection.Collection) {
 		return
 	}
 
-	err = c.AddFileFromReaderRaw(ModuleName+"/kernel.yml", &buf)
+	err = c.AddFileFromReaderRaw(filepath.Join(ModuleName, "kernel.yml"), &buf)
 	if err != nil {
 		c.Log.Error(err)
 	}

--- a/modules/corosync/collector.go
+++ b/modules/corosync/collector.go
@@ -3,6 +3,7 @@ package corosync
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "corosync"
@@ -61,10 +62,10 @@ func Collect(c *collection.Collection) {
 	}
 
 	for _, service := range services {
-		c.AddServiceStatusRaw(ModuleName+"/service-"+service+".txt", service)
+		c.AddServiceStatusRaw(filepath.Join(ModuleName, "service-"+service+".txt"), service)
 	}
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 }

--- a/modules/grafana/collector.go
+++ b/modules/grafana/collector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "grafana"
@@ -50,14 +51,14 @@ func Collect(c *collection.Collection) {
 
 	c.RegisterObfuscators(obfuscators...)
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*grafana*", "*chrome*", "*chromium*")
-	c.AddServiceStatusRaw(ModuleName+"/service.txt", "grafana-server")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*grafana*", "*chrome*", "*chromium*")
+	c.AddServiceStatusRaw(filepath.Join(ModuleName, "service.txt"), "grafana-server")
 
 	for _, file := range files {
 		c.AddFiles(ModuleName, file)
 	}
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 }

--- a/modules/graphite/collector.go
+++ b/modules/graphite/collector.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
 	"github.com/NETWAYS/support-collector/pkg/util"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "graphite"
@@ -79,10 +80,10 @@ func Collect(c *collection.Collection) {
 		}
 
 		for name, cmd := range commandsPython {
-			c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+			c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 		}
 
-		c.AddInstalledPackagesRaw(ModuleName+"/packages-python"+suffix+".txt", "*python"+suffix+"*")
+		c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages-python"+suffix+".txt"), "*python"+suffix+"*")
 	}
 
 	if !pythonFound {
@@ -109,11 +110,11 @@ func Collect(c *collection.Collection) {
 
 	for name, element := range journalctlLogs {
 		if service, err := collection.FindServices(element.Service); err == nil && len(service) > 0 {
-			c.AddCommandOutput(ModuleName+"/"+name, "journalctl", "-u", element.Service, "--since", timestamp)
+			c.AddCommandOutput(filepath.Join(ModuleName, name), "journalctl", "-u", element.Service, "--since", timestamp)
 		}
 	}
 
-	c.AddFileDataRaw(ModuleName+"/processlist.txt", []byte(processes))
+	c.AddFileDataRaw(filepath.Join(ModuleName, "processlist.txt"), []byte(processes))
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages-graphite.txt", "*graphite*", "*carbon*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages-graphite.txt"), "*graphite*", "*carbon*")
 }

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -5,6 +5,7 @@ import (
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 const ModuleName = "icinga2"
@@ -63,16 +64,16 @@ func Collect(c *collection.Collection) {
 
 	c.RegisterObfuscators(obfuscators...)
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt",
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"),
 		"*icinga2*",
 		"netways-plugin*",
 		"monitoring-plugin*",
 		"nagios-*")
 
-	c.AddServiceStatusRaw(ModuleName+"/service.txt", "icinga2")
+	c.AddServiceStatusRaw(filepath.Join(ModuleName, "service.txt"), "icinga2")
 
 	if collection.DetectServiceManager() == "systemd" {
-		c.AddCommandOutput(ModuleName+"/systemd-icinga2.service", "systemctl", "cat", "icinga2.service")
+		c.AddCommandOutput(filepath.Join(ModuleName, "systemd-icinga2.service"), "systemctl", "cat", "icinga2.service")
 	}
 
 	for _, file := range files {
@@ -90,7 +91,7 @@ func Collect(c *collection.Collection) {
 	}
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 
 	for _, file := range possibleDaemons {

--- a/modules/icingadb/collector.go
+++ b/modules/icingadb/collector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -62,7 +63,7 @@ func Collect(c *collection.Collection) {
 
 	c.RegisterObfuscators(obfuscators...)
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt",
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"),
 		"*icingadb*",
 		"icingadb-redis",
 	)
@@ -80,12 +81,12 @@ func Collect(c *collection.Collection) {
 	}
 
 	for _, service := range services {
-		c.AddServiceStatusRaw(ModuleName+"/service-"+service+".txt", service)
+		c.AddServiceStatusRaw(filepath.Join(ModuleName, "service-"+service+".txt"), service)
 	}
 
 	for name, element := range journalctlLogs {
 		if service, err := collection.FindServices(element.Service); err == nil && len(service) > 0 {
-			c.AddCommandOutput(ModuleName+"/"+name, "journalctl", "-u", element.Service, "--since", "7 days ago")
+			c.AddCommandOutput(filepath.Join(ModuleName, name), "journalctl", "-u", element.Service, "--since", "7 days ago")
 		}
 	}
 }

--- a/modules/icingadirector/collector.go
+++ b/modules/icingadirector/collector.go
@@ -3,6 +3,7 @@ package icingadirector
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -40,13 +41,13 @@ func Collect(c *collection.Collection) {
 
 	c.Log.Info("Collecting Icinga Director information")
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*icinga*director*")
-	c.AddServiceStatusRaw(ModuleName+"/service.txt", "icinga-director")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*icinga*director*")
+	c.AddServiceStatusRaw(filepath.Join(ModuleName, "service.txt"), "icinga-director")
 
 	// TODO: more infos on modules, GIT details
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 
 	for _, file := range possibleDaemons {
@@ -55,12 +56,12 @@ func Collect(c *collection.Collection) {
 
 	for name, element := range journalctlLogs {
 		if service, err := collection.FindServices(element.Service); err == nil && len(service) > 0 {
-			c.AddCommandOutput(ModuleName+"/"+name, "journalctl", "-u", element.Service, "--since \"7 days ago\"")
+			c.AddCommandOutput(filepath.Join(ModuleName, name), "journalctl", "-u", element.Service, "--since \"7 days ago\"")
 		}
 	}
 
 	// Get GIT Repository details
 	if path, ok := collection.IsGitRepository(InstallationPath); collection.DetectGitInstalled() && ok {
-		c.AddGitRepoInfo(ModuleName+"/git-info.yml", path)
+		c.AddGitRepoInfo(filepath.Join(ModuleName, "git-info.yml"), path)
 	}
 }

--- a/modules/icingaweb2/collector.go
+++ b/modules/icingaweb2/collector.go
@@ -80,10 +80,10 @@ func Collect(c *collection.Collection) {
 
 	c.RegisterObfuscators(obfuscators...)
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*icingaweb2*", "*icingacli*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*icingaweb2*", "*icingacli*")
 
 	if _, ok := collection.IsGitRepository("/usr/share/icingaweb2"); ok {
-		c.AddGitRepoInfo(ModuleName+"/git.yml", "/usr/share/icingaweb2")
+		c.AddGitRepoInfo(filepath.Join(ModuleName, "git.yml"), "/usr/share/icingaweb2")
 	}
 
 	CollectModuleInfo(c)
@@ -105,11 +105,11 @@ func Collect(c *collection.Collection) {
 	}
 
 	// Detect PHP related packages and services
-	c.AddInstalledPackagesRaw(ModuleName+"/packages-php.txt", "*php*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages-php.txt"), "*php*")
 
 	if services, err := collection.FindServices("*php*-fpm"); err == nil && len(services) > 0 {
 		for _, name := range services {
-			c.AddServiceStatusRaw(ModuleName+"/service-"+name+".txt", name)
+			c.AddServiceStatusRaw(filepath.Join(ModuleName, "service-"+name+".txt"), name)
 		}
 	}
 
@@ -117,12 +117,12 @@ func Collect(c *collection.Collection) {
 
 	for name, element := range journalctlLogs {
 		if service, err := collection.FindServices(element.Service); err == nil && len(service) > 0 {
-			c.AddCommandOutput(ModuleName+"/"+name, "journalctl", "-u", element.Service, "--since", timestamp)
+			c.AddCommandOutput(filepath.Join(ModuleName, name), "journalctl", "-u", element.Service, "--since", timestamp)
 		}
 	}
 
 	// Detect webserver packages
-	c.AddInstalledPackagesRaw(ModuleName+"/packages-webserver.txt", "*apache*", "*httpd*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages-webserver.txt"), "*apache*", "*httpd*")
 }
 
 func CollectModuleInfo(c *collection.Collection) {

--- a/modules/influxdb/collector.go
+++ b/modules/influxdb/collector.go
@@ -3,6 +3,7 @@ package influxdb
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "influxdb"
@@ -35,8 +36,8 @@ func Collect(c *collection.Collection) {
 
 	c.Log.Info("Collecting InfluxDB information")
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*influx*")
-	c.AddServiceStatusRaw(ModuleName+"/service.txt", "influxdb")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*influx*")
+	c.AddServiceStatusRaw(filepath.Join(ModuleName, "service.txt"), "influxdb")
 
 	for _, file := range files {
 		c.AddFiles(ModuleName, file)

--- a/modules/keepalived/collector.go
+++ b/modules/keepalived/collector.go
@@ -4,6 +4,7 @@ import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "keepalived"
@@ -63,10 +64,10 @@ func Collect(c *collection.Collection) {
 	}
 
 	for _, service := range services {
-		c.AddServiceStatusRaw(ModuleName+"/service-"+service+".txt", service)
+		c.AddServiceStatusRaw(filepath.Join(ModuleName, "service-"+service+".txt"), service)
 	}
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 }

--- a/modules/mysql/collector.go
+++ b/modules/mysql/collector.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -54,12 +55,12 @@ func Collect(c *collection.Collection) {
 
 	c.Log.Info("Collecting MySQL/MariaDB information")
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*mysql*", "*mariadb*")
-	c.AddServiceStatusRaw(ModuleName+"/service.txt", service)
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*mysql*", "*mariadb*")
+	c.AddServiceStatusRaw(filepath.Join(ModuleName, "service.txt"), service)
 	c.AddFilesIfFound(ModuleName, possibleConfigPaths...)
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 
 	for _, file := range optionalFiles {

--- a/modules/postgresql/collector.go
+++ b/modules/postgresql/collector.go
@@ -3,6 +3,7 @@ package postgresql
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "postgresql"
@@ -44,14 +45,14 @@ func Collect(c *collection.Collection) {
 
 	c.Log.Info("Collecting PostgreSQL information")
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*postgresql*", "*pgsql*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*postgresql*", "*pgsql*")
 	c.AddFilesIfFound(ModuleName, files...)
 
 	for _, service := range possibleServices {
-		c.AddServiceStatusRaw(ModuleName+"/service-"+service+".txt", service)
+		c.AddServiceStatusRaw(filepath.Join(ModuleName, "service-"+service+".txt"), service)
 	}
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 }

--- a/modules/puppet/collector.go
+++ b/modules/puppet/collector.go
@@ -3,6 +3,7 @@ package puppet
 import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"os"
+	"path/filepath"
 )
 
 const ModuleName = "puppet"
@@ -51,12 +52,12 @@ func Collect(c *collection.Collection) {
 	}
 
 	for name, cmd := range commands {
-		c.AddCommandOutput(ModuleName+"/"+name, cmd[0], cmd[1:]...)
+		c.AddCommandOutput(filepath.Join(ModuleName, name), cmd[0], cmd[1:]...)
 	}
 
-	c.AddInstalledPackagesRaw(ModuleName+"/packages.txt", "*puppet*")
+	c.AddInstalledPackagesRaw(filepath.Join(ModuleName, "packages.txt"), "*puppet*")
 
 	for _, service := range possibleServices {
-		c.AddServiceStatusRaw(ModuleName+"/service-"+service+".txt", service)
+		c.AddServiceStatusRaw(filepath.Join(ModuleName, "service-"+service+".txt"), service)
 	}
 }


### PR DESCRIPTION
To avoid errors like XYZ, it makes more sense to build the paths of the files using filepath.Join()

https://pkg.go.dev/path/filepath#Join