### PR TITLE
build icinga2.debug if Icinga 2 version >= 2.14

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,7 @@ linters:
     - interfacer # deprecated since v1.38.0
     - ifshort # v1.48.0
     - musttag
+    - lll # disable line length
   enable:
     - exportloopref
     - revive

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -106,6 +106,7 @@ func Collect(c *collection.Collection) {
 		c.AddFiles(ModuleName, file)
 	}
 
+	// With Icinga 2 >= 2.14 the icinga2.debug cache is no longer built automatically on every reload. To retrieve a current state we build it manually (only possible from 2.14.0)
 	version, err := detectIcingaVersion()
 	if err != nil {
 		c.Log.Warn("cant detect Icinga 2 version")

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -62,7 +62,7 @@ func detectIcingaVersion() (string, error) {
 		return "", err
 	}
 
-	result := regexp.MustCompile(`\(version:\s+r(\d+.\d+.\d+)`).FindStringSubmatch(string(out))
+	result := regexp.MustCompile("\\(version:\\s+r(\\d+.\\d+.\\d+)").FindStringSubmatch(string(out))
 	if result == nil {
 		return "", err
 	}

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -62,7 +62,7 @@ func detectIcingaVersion() (string, error) {
 		return "", err
 	}
 
-	result := regexp.MustCompile("\\(version:\\s+r(\\d+.\\d+.\\d+)").FindStringSubmatch(string(out))
+	result := regexp.MustCompile(`\(version:\s+r(\d+.\d+.\d+)`).FindStringSubmatch(string(out))
 	if result == nil {
 		return "", err
 	}

--- a/modules/icinga2/collector_test.go
+++ b/modules/icinga2/collector_test.go
@@ -5,10 +5,21 @@ import (
 	"github.com/NETWAYS/support-collector/pkg/collection"
 	"github.com/NETWAYS/support-collector/pkg/obfuscate"
 	"github.com/NETWAYS/support-collector/pkg/util"
+	"os"
 	"testing"
 )
 
 func TestCollect(t *testing.T) {
+	file, err := os.ReadFile("testdata/icinga-version.txt")
+	if err != nil {
+		t.Skip("cant read version file")
+	}
+
+	version := detectIcingaVersion(string(file))
+	if version == "" {
+		t.Skip("cant detect icinga2 version")
+	}
+
 	if !detectIcinga() {
 		t.Skip("could not find icinga2 in the test environment")
 		return

--- a/modules/icinga2/collector_test.go
+++ b/modules/icinga2/collector_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCollect(t *testing.T) {
-	if !DetectIcinga() {
+	if !detectIcinga() {
 		t.Skip("could not find icinga2 in the test environment")
 		return
 	}

--- a/modules/icinga2/testdata/icinga-version.txt
+++ b/modules/icinga2/testdata/icinga-version.txt
@@ -1,0 +1,42 @@
+icinga2 - The Icinga 2 network monitoring daemon (version: r2.14.0-1)
+
+Copyright (c) 2012-2023 Icinga GmbH (https://icinga.com/)
+License GPLv2+: GNU GPL version 2 or later <https://gnu.org/licenses/gpl2.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+
+System information:
+  Platform: Ubuntu
+  Platform version: 22.04.2 LTS (Jammy Jellyfish)
+  Kernel: Linux
+  Kernel version: 5.15.0-76-generic
+  Architecture: x86_64
+
+Build information:
+  Compiler: GNU 11.3.0
+  Build host: runner-hh8q3bz2-project-575-concurrent-0
+  OpenSSL version: OpenSSL 3.0.2 15 Mar 2022
+
+Application information:
+
+General paths:
+  Config directory: /etc/icinga2
+  Data directory: /var/lib/icinga2
+  Log directory: /var/log/icinga2
+  Cache directory: /var/cache/icinga2
+  Spool directory: /var/spool/icinga2
+  Run directory: /run/icinga2
+
+Old paths (deprecated):
+  Installation root: /usr
+  Sysconf directory: /etc
+  Run directory (base): /run
+  Local state directory: /var
+
+Internal paths:
+  Package data directory: /usr/share/icinga2
+  State path: /var/lib/icinga2/icinga2.state
+  Modified attributes path: /var/lib/icinga2/modified-attributes.conf
+  Objects path: /var/cache/icinga2/icinga2.debug
+  Vars path: /var/cache/icinga2/icinga2.vars
+  PID path: /run/icinga2/icinga2.pid


### PR DESCRIPTION
To get the current state in `icinga2 object list` it is necessary to build the icinga2.debug since 2.14.0.  
This is done with `icinga2 daemon -C --dump-objects`

fixes #93 