### PR TITLE
change logging verbosity

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,16 +145,16 @@ func main() {
 	for _, name := range moduleOrder {
 		switch {
 		case util.StringInSlice(name, disabledModules):
-			c.Log.Infof("Module %s is disabled", name)
+			c.Log.Debugf("Module %s is disabled", name)
 		case !util.StringInSlice(name, enabledModules):
-			c.Log.Infof("Module %s is not enabled", name)
+			c.Log.Debugf("Module %s is not enabled", name)
 		default:
 			moduleStart := time.Now()
 
-			c.Log.Debugf("Calling module %s", name)
+			c.Log.Debugf("Start collecting data for module %s", name)
 
 			for _, o := range extraObfuscators {
-				c.Log.Debugf("Adding obfuscator for '%s' to module %s", o, name)
+				c.Log.Debugf("Adding custom obfuscator for '%s' to module %s", o, name)
 				c.RegisterObfuscator(obfuscate.NewAny(o))
 			}
 

--- a/modules/graphite/collector.go
+++ b/modules/graphite/collector.go
@@ -92,7 +92,7 @@ func Collect(c *collection.Collection) {
 	}
 
 	if !pythonFound {
-		c.Log.Warn("Python not found on system")
+		c.Log.Debug("Python not found on system")
 	}
 
 	for _, file := range files {
@@ -101,7 +101,7 @@ func Collect(c *collection.Collection) {
 
 	processList, err := collection.ProcessListFilter(processFilter)
 	if err != nil {
-		c.Log.Warn("cant get process list")
+		c.Log.Debug("cant get process list")
 	}
 
 	// save process names to string array

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -114,7 +114,7 @@ func Collect(c *collection.Collection) {
 
 	content, err := collection.LoadCommandOutput("icinga2", "-V")
 	if err != nil {
-		c.Log.Info("Could not find icinga2")
+		c.Log.Debug("Could not find executable for icinga2")
 
 		icinga2version = ""
 	} else {

--- a/modules/icingaweb2/collector.go
+++ b/modules/icingaweb2/collector.go
@@ -135,12 +135,12 @@ func Collect(c *collection.Collection) {
 
 func CollectModuleInfo(c *collection.Collection) {
 	if !collection.DetectGitInstalled() {
-		c.Log.Warnf("we need git to inspect modules closer")
+		c.Log.Debug("we need git to inspect modules closer")
 	}
 
 	modulesFiles, err := os.ReadDir(ModulesPath)
 	if err != nil {
-		c.Log.Warnf("Could not list modules in %s - %s", ModulesPath, err)
+		c.Log.Debugf("Could not list modules in %s - %s", ModulesPath, err)
 		return
 	}
 

--- a/pkg/collection/collection.go
+++ b/pkg/collection/collection.go
@@ -131,7 +131,7 @@ func (c *Collection) AddFileYAML(fileName string, data interface{}) {
 
 	err := yaml.NewEncoder(&buf).Encode(&data)
 	if err != nil {
-		c.Log.Warnf("could not encode YAML data for '%s': %s", fileName, err)
+		c.Log.Debugf("could not encode YAML data for '%s': %s", fileName, err)
 	}
 
 	file := NewFile(fileName)
@@ -145,7 +145,7 @@ func (c *Collection) AddFiles(prefix, source string) {
 
 	files, err := LoadFiles(prefix, source)
 	if err != nil {
-		c.Log.Warn(err)
+		c.Log.Debug(err)
 	}
 
 	for _, file := range files {
@@ -182,13 +182,13 @@ func (c *Collection) AddCommandOutputWithTimeout(file string,
 
 	output, err := LoadCommandOutputWithTimeout(timeout, command, arguments...)
 	if err != nil {
-		c.Log.Warn(err)
+		c.Log.Debug(err)
 	}
 
 	// obfuscate
 	output, err = c.callObfuscators(obfuscate.KindOutput, obfuscate.JoinCommand(command, arguments...), output)
 	if err != nil {
-		c.Log.Warn(err)
+		c.Log.Debug(err)
 	}
 
 	c.AddFileDataRaw(file, output)
@@ -203,7 +203,7 @@ func (c *Collection) AddInstalledPackagesRaw(fileName string, pattern ...string)
 
 	packages, err := ListInstalledPackagesRaw(pattern...)
 	if err != nil {
-		c.Log.Warn(err)
+		c.Log.Debug(err)
 	}
 
 	c.AddFileDataRaw(fileName, packages)
@@ -214,7 +214,7 @@ func (c *Collection) AddServiceStatusRaw(fileName, name string) {
 
 	output, err := GetServiceStatusRaw(name)
 	if err != nil {
-		c.Log.Warn(err)
+		c.Log.Debug(err)
 	}
 
 	c.AddFileDataRaw(fileName, output)
@@ -225,7 +225,7 @@ func (c *Collection) AddGitRepoInfo(fileName, path string) {
 
 	info, err := LoadGitRepoInfo(path)
 	if err != nil {
-		c.Log.Warn(err)
+		c.Log.Debug(err)
 	}
 
 	c.AddFileYAML(fileName, info)


### PR DESCRIPTION
The tool works according to the "we get what we can" principle. If it doesn't find something, which is perfectly possible and okay, no warnings should be thrown.

A detailed log of the commands not executed or the files not found can be found in the run log itself.