### PR TITLE
Introduce run metrics

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,6 +42,6 @@ linters:
 linters-settings:
    funlen:
      ignore-comments: true
-     lines: 75
+     lines: 80
    nestif:
      min-complexity: 5

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"github.com/NETWAYS/support-collector/internal/obfuscate"
+	"os"
+	"strings"
+	"time"
+)
+
+type Metrics struct {
+	Command string                   `json:"command"`
+	Version string                   `json:"version"`
+	Timings map[string]time.Duration `json:"timings"`
+}
+
+// New creates new Metrics
+func New(version string) (m *Metrics) {
+	return &Metrics{
+		Command: getCommand(),
+		Version: version,
+		Timings: make(map[string]time.Duration),
+	}
+}
+
+// getCommand returns the executed command and obfusactes *--icinga2* arguments
+func getCommand() string {
+	args := os.Args
+
+	// Obfuscate icinga 2 api user and password
+	for i, arg := range args {
+		if strings.Contains(arg, "--icinga2") && i+1 < len(args) {
+			args[i+1] = obfuscate.Replacement
+		}
+	}
+
+	return strings.Join(args, " ")
+}

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -125,8 +125,12 @@ func Collect(c *collection.Collection) {
 	}
 
 	// With Icinga 2 >= 2.14 the icinga2.debug cache is no longer built automatically on every reload. To retrieve a current state we build it manually (only possible from 2.14.0)
+	// Needs to be done before commands are collected
 	if icinga2version >= "2.14.0" {
-		c.AddCommandOutput("dump-objects.txt", "icinga2", "daemon", "-C", "--dump-objects")
+		_, err = collection.LoadCommandOutput("icinga2", "daemon", "-C", "--dump-objects")
+		if err != nil {
+			c.Log.Warn(err)
+		}
 	}
 
 	for name, cmd := range commands {

--- a/version.go
+++ b/version.go
@@ -10,7 +10,7 @@ var (
 )
 
 //goland:noinspection GoBoolExpressions
-func buildVersion() string {
+func getBuildInfo() string {
 	result := version
 
 	if commit != "" {
@@ -22,4 +22,8 @@ func buildVersion() string {
 	}
 
 	return result
+}
+
+func getVersion() string {
+	return version
 }


### PR DESCRIPTION
Introduce metrics about the collection.
* How is the command called? (Values from \*--icinga2\* are obfuscated)
* Move timings from timing.yml to metrics
* Version

Metrics will be saved to metrics.json

```
{"command":"/home/ubuntu/support-collector/executables-Gbx8dzGyfT/___go_build_github_com_NETWAYS_support_collector_linux --icinga2-api-user \u003cHIDDEN\u003e --icinga2-api-pass \u003cHIDDEN\u003e --icinga2-api-endpoints \u003cHIDDEN\u003e --enable webservers","version":"0.10.1","timings":{"total":32594129,"webservers":32254571}}
```