### PR TITLE
Update obfuscation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: 1.23
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,4 +15,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.56.2
+          version: v1.61

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,5 @@ test:
 coverage:
 	go test -v -cover -coverprofile=coverage.out ./... &&\
 	go tool cover -html=coverage.out -o coverage.html
+clean:
+	rm -f support-collector_*.zip

--- a/README.md
+++ b/README.md
@@ -28,9 +28,13 @@ You can also combine your CLI arguments and the wizard. All arguments you pass f
 
 > **WARNING:** Some passwords or secrets are automatically removed, but this no guarantee, so be careful what you share!
 
-The `--hide` flag can be used multiple times to hide sensitive data, it supports regular expressions.
+The `--hide` flag can be used multiple times to hide sensitive data.  
+As these obfuscators are based on regex, you must add a regex pattern that meets your requirements.
 
-`# support-collector --hide "Secret:.*" --hide "Password:.*"`
+`# support-collector --hide "Secret:\s*(.*)"`
+
+This will replace:
+* Values like `Secret: DummyValue`
 
 In addition, files and folders that follow a specific pattern are not collected. This affects all files that correspond to the following filters:  
 `.*`, `*~`, `*.key`, `*.csr`, `*.crt`, and `*.pem`

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/NETWAYS/support-collector
 
-go 1.20
+go 1.22
 
 require (
 	github.com/Showmax/go-fqdn v1.0.0

--- a/internal/collection/collection.go
+++ b/internal/collection/collection.go
@@ -3,7 +3,6 @@ package collection
 import (
 	"archive/zip"
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -142,22 +141,18 @@ func (c *Collection) AddFileYAML(fileName string, data interface{}) {
 	_ = c.AddFileToOutput(file)
 }
 
-// AddFileJSON will add raw file data without obfuscation
+// AddFileJSON will add json data and apply obfuscation
 func (c *Collection) AddFileJSON(fileName string, data []byte) {
-	var jsonData interface{}
-
-	err := json.Unmarshal(data, &jsonData)
-	if err != nil {
-		c.Log.Debugf("could not unmarshal JSON data for '%s': %s", fileName, err)
-	}
-
-	prettyJSON, err := json.MarshalIndent(jsonData, "", "")
-	if err != nil {
-		c.Log.Debugf("could not marshal JSON data for '%s': %s", fileName, err)
-	}
-
 	file := NewFile(fileName)
-	file.Data = prettyJSON
+	file.Data = data
+
+	_ = c.AddFileToOutput(file)
+}
+
+// AddFileJSONRaw will add raw json data without obfuscation
+func (c *Collection) AddFileJSONRaw(fileName string, data []byte) {
+	file := NewFile(fileName)
+	file.Data = data
 
 	_ = c.AddFileToOutputRaw(file)
 }

--- a/internal/util/testing.go
+++ b/internal/util/testing.go
@@ -19,7 +19,7 @@ func AssertObfuscation(t *testing.T, obfuscators []*obfuscate.Obfuscator,
 			continue
 		}
 
-		_, out, err := o.Process([]byte(input))
+		_, out, err := o.Process([]byte(input), name)
 		if err != nil {
 			t.Errorf("error during obfuscation: %s", err)
 			return

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -20,9 +20,10 @@ func StringInSlice(a string, list []string) bool {
 	return false
 }
 
-// DistinctStringSlice retuns the given slice with unique values
+// DistinctStringSlice returns the given slice with unique values
 func DistinctStringSlice(arr []string) []string {
 	seen := make(map[string]bool)
+
 	var result []string
 
 	for _, val := range arr {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -20,6 +20,21 @@ func StringInSlice(a string, list []string) bool {
 	return false
 }
 
+// DistinctStringSlice retuns the given slice with unique values
+func DistinctStringSlice(arr []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+
+	for _, val := range arr {
+		if !seen[val] {
+			result = append(result, val)
+			seen[val] = true
+		}
+	}
+
+	return result
+}
+
 // IsPrivilegedUser returns true when the current user is root.
 func IsPrivilegedUser() bool {
 	u, err := user.Current()

--- a/main.go
+++ b/main.go
@@ -220,7 +220,7 @@ func main() {
 			c.Log.Warn("cant unmarshal metrics: %w", err)
 		}
 
-		c.AddFileJSON("metrics.json", body)
+		c.AddFileJSONRaw("metrics.json", body)
 	}()
 
 	if noDetailedCollection {

--- a/main.go
+++ b/main.go
@@ -246,16 +246,19 @@ func main() {
 	c.Log.Infof("Collection complete, took us %.3f seconds", metric.Timings["total"].Seconds())
 
 	// Collect obfuscation info
-	var files, count uint
+	var (
+		count         uint
+		affectedFiles []string
+	)
 
 	for _, o := range c.Obfuscators {
-		files += o.Files
-
 		count += o.Replaced
+
+		affectedFiles = append(affectedFiles, o.ObfuscatedFiles...)
 	}
 
-	if files > 0 {
-		c.Log.Infof("Obfuscation replaced %d token in %d files (%d definitions)", count, files, len(c.Obfuscators))
+	if len(affectedFiles) > 0 {
+		c.Log.Infof("Obfuscation replaced %d token in %d files (%d definitions)", count, len(util.DistinctStringSlice(affectedFiles)), len(c.Obfuscators))
 	}
 
 	// get absolute path of outputFile

--- a/modules/base/kernel.go
+++ b/modules/base/kernel.go
@@ -54,7 +54,7 @@ func CharsToString(chars []int8) string {
 			break
 		}
 
-		s[i] = uint8(chars[i])
+		s[i] = byte(chars[i])
 	}
 
 	return string(s[0:i])

--- a/modules/icinga2/api.go
+++ b/modules/icinga2/api.go
@@ -60,7 +60,7 @@ func InitAPICollection(c *collection.Collection) error {
 
 // endpointIsReachable checks if the given endpoint is reachable within 5 sec
 func endpointIsReachable(endpoint string) error {
-	timeout := 5 * time.Second
+	timeout := 5 * time.Second //nolint:mnd
 
 	// try to dial tcp connection within 5 seconds
 	conn, err := net.DialTimeout("tcp", endpoint, timeout)
@@ -84,7 +84,7 @@ func collectStatus(endpoint string, c *collection.Collection) error {
 	client := &http.Client{Transport: tr}
 
 	// build context for request
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) //nolint:mnd
 	defer cancel()
 
 	// build request

--- a/modules/icinga2/collector.go
+++ b/modules/icinga2/collector.go
@@ -1,13 +1,13 @@
 package icinga2
 
 import (
+	"github.com/NETWAYS/support-collector/internal/obfuscate"
 	"github.com/NETWAYS/support-collector/internal/util"
 	"os"
 	"path/filepath"
 	"regexp"
 
 	"github.com/NETWAYS/support-collector/internal/collection"
-	"github.com/NETWAYS/support-collector/internal/obfuscate"
 )
 
 const ModuleName = "icinga2"


### PR DESCRIPTION
Currently there is a problem with obfuscators that have more than one replacement.  

* Updated README for obfuscation. (Just added the basics because the flag `--hide`, will be replaced with #135)
* Updated processing of resources in case we have several Replacements inside of an `Obfuscators`
* Renamed some Variables for better understandability