### PR TITLE
fetch system overcommit_memory

### DIFF
--- a/modules/icingadb/collector.go
+++ b/modules/icingadb/collector.go
@@ -21,6 +21,7 @@ var files = []string{
 	"/etc/icingadb",
 	"/etc/icingadb-redis",
 	"/etc/icinga2/features-enabled/icingadb.conf",
+	"/proc/sys/vm/overcommit_memory",
 }
 
 var detailedFiles = []string{

--- a/modules/redis/collector.go
+++ b/modules/redis/collector.go
@@ -16,6 +16,7 @@ var relevantPaths = []string{
 
 var files = []string{
 	"/etc/redis*",
+	"/proc/sys/vm/overcommit_memory",
 }
 
 var optionalFiles = []string{


### PR DESCRIPTION
We fetch in this PR information about the value of **overcommit_memory** on system which is relevant for icingadb/redis module.

fixes #134 