### PR TITLE
Replace Showmax/go-fqdn dependency with function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/NETWAYS/support-collector
 go 1.25.0
 
 require (
-	github.com/Showmax/go-fqdn v1.0.0
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/spf13/pflag v1.0.10
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Showmax/go-fqdn v1.0.0 h1:0rG5IbmVliNT5O19Mfuvna9LL7zlHyRfsSvBPZmF9tM=
-github.com/Showmax/go-fqdn v1.0.0/go.mod h1:SfrFBzmDCtCGrnHhoDjuvFnKsWjEQX/Q9ARZvOrJAko=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
 github.com/mitchellh/go-ps v1.0.0/go.mod h1:J4lOc8z8yJs6vUwklHw2XEIiT4z4C40KtWVN3nvg8Pg=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=

--- a/modules/base/kernel.go
+++ b/modules/base/kernel.go
@@ -1,11 +1,13 @@
 package base
 
 import (
+	"context"
 	"fmt"
+	"net"
+	"os"
+	"strings"
 	"syscall"
 	"time"
-
-	"github.com/Showmax/go-fqdn"
 )
 
 type KernelInfo struct {
@@ -17,6 +19,40 @@ type KernelInfo struct {
 	Domainname  string
 	FQDN        string
 	CurrentTime string
+}
+
+func getFQDN() (string, error) {
+	hostname, err := os.Hostname()
+	if err != nil {
+		return "", err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	defer cancel()
+
+	resolver := &net.Resolver{
+		PreferGo: true,
+	}
+
+	addrs, err := resolver.LookupHost(ctx, hostname)
+	if err != nil {
+		return hostname, nil
+	}
+
+	for _, addr := range addrs {
+		hosts, err := resolver.LookupAddr(ctx, addr)
+
+		if err != nil || len(hosts) == 0 {
+			continue
+		}
+
+		fqdn := strings.TrimSuffix(hosts[0], ".")
+
+		return fqdn, nil
+	}
+
+	return hostname, nil
 }
 
 func GetKernelInfo() (i KernelInfo, err error) {
@@ -37,7 +73,7 @@ func GetKernelInfo() (i KernelInfo, err error) {
 		Domainname: CharsToString(uname.Domainname[:]),
 	}
 
-	i.FQDN, err = fqdn.FqdnHostname()
+	i.FQDN, err = getFQDN()
 	// return err after setting info
 
 	i.CurrentTime = time.Now().String()


### PR DESCRIPTION
go-fqdn uses net.LookupCNAME without a context/timeout. This replaces the dependency with net.Resolver that uses a timeout